### PR TITLE
Added django-flat-theme by @elky under Admin Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A curated list of awesome Django apps, projects and resources. Inspired by and b
 
 *Packages that extend the Admin interface, adding or improving features.*
 
+* [django-flat-theme](https://github.com/elky/django-flat-theme) - A flat theme for Django admin interface. Modern, fresh, simple.
 * [djamin](https://github.com/hersonls/djamin/) - A new style for Django admin.
 * [django-admin-bootstrap](https://github.com/douglasmiranda/django-admin-bootstrap/) - Responsible Skin for Django Admin
 * [django-admin-bootstrapped](https://github.com/django-admin-bootstrapped/django-admin-bootstrapped/) - A Django admin theme using Twitter Bootstrap.


### PR DESCRIPTION
django-flat-theme brings fresh air to the default Django Admin interface which hasn't changed 10 years from the very first version of Django framework. This theme just makes UI modern and clean.

This app just overrides default admin's CSS. All changes are about colors, margins, sizes. Nothing major.