### PR TITLE
Fixes #111

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,6 @@ Where to discover new Django apps and projects.
 * [Getting started with Django](http://gettingstartedwithdjango.com/) (video)
 * [Tango With Django](http://www.tangowithdjango.com/) (1.5)
 * [Test-Driven Web Development with Python](http://chimera.labs.oreilly.com/books/1234000000754/index.html) (1.7)
-* [The Django book](http://www.djangobook.com/en/2.0/)
 * [Two Scoops of Django: Best Practices for Django 1.6](http://twoscoopspress.org/products/two-scoops-of-django-1-6/) - Making Python and Django as fun as ice cream.
 
 ## Websites


### PR DESCRIPTION
Per #111, Djangobook is dangerously outdated. There are better Django books coming out nearly every month now, and it's time we support them and completely, totally deprecate djangobook.