### PR TITLE
Adds django-versatileimagefield under two more relevant headings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ phone numbers.
 *Packages that help to manipulate, alter, or convert images.*
 
 * [django-image-cropping](https://github.com/jonasundderwolf/django-image-cropping) - helper application to easily and non-destructively crop arbitrarily large images in admin and frontend.
+* [django-versatileimagefield](https://github.com/WGBH/django-versatileimagefield/) - A drop-in replacement for django's ImageField that provides a flexible, intuitive and easily-extensible interface for quickly creating new images from the one assigned to the field.
 
 ## RESTful API
 
@@ -390,6 +391,7 @@ phone numbers.
 *Packages that help generate thumbnails.*
 
 * [django-stdimage](https://github.com/codingjoe/django-stdimage/) - Thumbnails and image utils for Django.
+* [django-versatileimagefield](https://github.com/WGBH/django-versatileimagefield/) - A drop-in replacement for django's ImageField that provides a flexible, intuitive and easily-extensible interface for quickly creating new images from the one assigned to the field.
 * [easy-thumbnails](https://github.com/SmileyChris/easy-thumbnails) - Easy thumbnails for Django.
 * [sorl-thumbnail](https://github.com/mariocesar/sorl-thumbnail/) - Thumbnails for Django.
 


### PR DESCRIPTION
Thanks for including my project, [django-versatileimagefield](https://github.com/WGBH/django-versatileimagefield), into `awesome-django`...I really appreciate it! Currently, django-versatileimagefield is only listed under the Fields heading. This PR includes a simple commit that includes the project under two more relevant headings: **Image** and **Thumbnails**.