### PR TITLE
Replace outdated djngo-seo

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ phone numbers.
 
 * [django-meta](https://github.com/nephila/django-meta/) - a pluggable app to allow Django developers to quickly add meta tags and OpenGraph, Twitter, and Google Plus properties to their HTML responses.
 * [django-robots](https://github.com/jezdez/django-robots) - A Django app for managing robots.txt files following the robots exclusion protocol.
-* [django-seo](https://github.com/willhardy/django-seo/) - Provides a set of tools for managing Search Engine Optimisation (SEO) for Django sites.
+* [django-seo2](https://github.com/romansalin/django-seo2/) - Provides a set of tools for managing Search Engine Optimisation (SEO) metadata for Django sites.
 
 ## Settings
 


### PR DESCRIPTION
django-seo is no longer maintained. This is actually the fork, which has many bugfixes, some improves, django 1.8 and 1.9 support.