### PR TITLE
Travis Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-dupe --white-list awesome-django,django-pagination,djangobeer,django-dynamic-preferences.
+  - awesome_bot README.md --allow-dupe --white-list awesome-django,django-pagination,djangobeer,django-dynamic-preferences.,djangovillage


### PR DESCRIPTION
This pull request white lists `djangovillage` so Travis does not fail.. the link currently redirects to http://2016.djangovillage.it/ and is likely to keep redirecting