### PR TITLE
Update Wagtail description

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ phone numbers.
 * [django-fiber](https://github.com/ridethepony/django-fiber) - Django Fiber, a simple, user-friendly CMS for all your Django projects
 * [feincms](https://github.com/feincms/feincms/) - A Django-based CMS with a focus on extensibility and concise code.
 * [Mezzanine](https://github.com/stephenmcd/mezzanine/) - A content management platform built using the Django framework.
-* [wagtail](https://github.com/torchbox/wagtail/) - A new Django content management system.
+* [wagtail](https://github.com/torchbox/wagtail/) - A Django content management system focused on flexibility and user experience.
 * [leonardo](https://github.com/django-leonardo/django-leonardo/) - A new Django content management system built on top of FeinCMS and OpenStack Horizon.
 
 ## Document Management


### PR DESCRIPTION
Wagtail isn't new anymore (current description is 2 years old), so here is the new description the project uses on its GitHub repo.
