### PR TITLE
Added link to django-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ phone numbers.
 * [django-overextends](https://github.com/stephenmcd/django-overextends) - Circular template inheritance for Django.
 * [django-pagination](https://github.com/ericflo/django-pagination) - https://github.com/ericflo/django-pagination.
 * [django-el-pagination](https://github.com/shtalinberg/django-el-pagination) - Django EL(Endless) Pagination can be used to provide Twitter-style or Digg-style pagination, with optional Ajax support.
+* [django-qa](https://github.com/swappsco/django-qa) - StackOverflow style Q & A application.
 * [django-quiz-app](https://github.com/tomwalker/django_quiz/) - This is a configurable quiz app for Django.
 * [django-recaptcha](https://github.com/praekelt/django-recaptcha/) - Django reCAPTCHA form field/widget integration app.
 * [django-smuggler](https://github.com/semente/django-smuggler/) - Django Smuggler is a pluggable application for Django Web Framework that helps you to import/export fixtures via the automatically-generated administration interface.


### PR DESCRIPTION
I've added a link to [django-qa](https://github.com/swappsco/django-qa/). 