### PR TITLE
Add djangoql to Search section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ phone numbers.
 * [django-haystack](https://github.com/django-haystack/django-haystack) - Modular search for Django.
 * [django-watson](https://github.com/etianen/django-watson/) - Fast multi-model full-text search plugin.
 * [djorm-ext-pgfulltext](https://github.com/linuxlewis/djorm-ext-pgfulltext) - PostgreSQL full-text search integration with django orm.
+* [djangoql](https://github.com/ivelum/djangoql) - Advanced search language for Django.
 
 ## Security
 


### PR DESCRIPTION
Advanced search language for Django, with auto-completion. Supports logical operators, parenthesis, table joins, works with any Django models. Tested vs. Python 2.7, 3.5 and 3.6, Django 1.8 - 1.11. Auto-completion feature tested in Chrome, Firefox, Safari, IE9+.