### PR TITLE
updated django-storages url

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ phone numbers.
 *Packages that extend the functionality of the existing storage backend or provide new storage backends.*
 
 * [django-selectel-storage](https://github.com/marazmiki/django-selectel-storage) - This application allows you easily save media and static files into [Selectel](https://selectel.ru/) cloud storage.
-* [django-storages](https://bitbucket.org/david/django-storages/src/) - django-storages is a collection of custom storage backends for Django.
+* [django-storages](https://github.com/jschneier/django-storages) - django-storages is a collection of custom storage backends for Django.
 * [django-queued-storage](https://github.com/jazzband/django-queued-storage) - Provides a proxy for Django storage backends that allows you to upload files locally and eventually serve them remotely.
 * [django-webdav-storage](https://github.com/marazmiki/django-webdav-storage) - Django storage backend that stores files in custom WebDAV storage.
 


### PR DESCRIPTION
Original django-storages repo is dead and was forked and development was continued in this repo.

From new repo [README file](https://github.com/jschneier/django-storages#history):

> This repo began as a fork of the original library under the package name of django-storages-redux and became the official successor (releasing under django-storages on PyPI) in February of 2016.