### PR TITLE
Add Angular-Django-Seed-Project to Boilerplate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Twitter feed: [twitter.com/AwesomeDjango](https://twitter.com/AwesomeDjango)
 * [cookiecutter](https://github.com/audreyr/cookiecutter/) - A command-line utility that creates projects from cookiecutters (project templates).
 * [django-hackathon-starter](https://github.com/DrkSephy/django-hackathon-starter) - A boilerplate for Django web applications, containing various social authentication methods and several popular API examples.
 * [edge](https://github.com/arocks/edge) - A Django project skeleton that is modern and cutting edge.
+* [Angular-Django-Seed-Project](https://github.com/nirgn975/Angular-Django-Seed-Project) - A production ready seed project for Angular and Django RESTful apps.
 
 ## Caching
 


### PR DESCRIPTION
Add the [Angular-Django-Seed-Project](https://github.com/nirgn975/Angular-Django-Seed-Project) to the `Boilerplate` section.

The Angular-Django-Seed-Project repo is an opinionated Angular - Django RESTful cluster seed. It's handle logging in ELK stack, Database backups, Load Tests with Locust, Scalability with docker and docker-swarm, have 90+ tests coverage, etc.